### PR TITLE
macOS环境下tesseract识别出的验证码比正确的验证码多了空格和换行符，去除之

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 /dist
 /sjtu_automata.egg-info
 /.vscode
+.idea/
+.DS_Store

--- a/sjtu_automata/credential.py
+++ b/sjtu_automata/credential.py
@@ -40,7 +40,7 @@ def _bypass_captcha(session, url, useocr):
         f.write(captcha.content)
 
     if useocr:
-        code = autocaptcha('captcha.jpeg')
+        code = autocaptcha('captcha.jpeg').strip()
         if not code.isalpha():
             code = '1234'   # cant recongnize, go for next round
     else:


### PR DESCRIPTION
感谢你写的Python程序，非常规范。
我在最新版的macOS下测试本程序，发现tesseract识别出的验证码比正确的验证码在最后多了空格和换行符，所以用strip函数去除多余的空格和换行符。