### PR TITLE
Don't let setup.py import __init__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import setuptools
-from sjtu_automata.__version__ import __title__, __description__, __url__, __version__, __author__, __author_email__, __license__
+
+with open('sjtu_automata/__version__.py') as fp:
+    exec(fp.read())
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()


### PR DESCRIPTION
Currently,  `pip install git+https://github.com/MXWXZ/sjtu-automata` will throw error like this
```
error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [22 lines of output]
...
        File "/tmp/pip-build-env-byqpqeoz/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 304, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-byqpqeoz/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 522, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-byqpqeoz/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 320, in run_setup
          exec(code, locals())
        File "<string>", line 2, in <module>
        File "/tmp/pip-req-build-oogbl43e/sjtu_automata/__init__.py", line 3, in <module>
          import requests
      ModuleNotFoundError: No module named 'requests'
      [end of output]
```

See https://packaging.python.org/en/latest/guides/single-sourcing-package-version/