### PR TITLE
Fix JAccount login API (JSON response), OCR loops, and update README guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,25 @@ macOS
 
 其他版本/发行版/Windows等自行看文档：https://github.com/tesseract-ocr/tesseract/wiki
     
-## 简单使用说明
+## 简单使用说明 & 避坑指南
+
+**注意：目前 pip 仓库的 0.4.0 版本已失效。请下载本仓库最新源码，并在本地运行！**
+
 - 由于选课系统再次更新，需要传递的参数改变，因此建议使用油猴脚本获取ID：https://www.tampermonkey.net/
 - 插件安装完成后点击这里进入脚本安装页面：https://github.com/MXWXZ/sjtu-automata/raw/master/sjtu-automata.user.js
 - 下面的教程以安装插件之后为准，如果不安装油猴脚本也可以自行查看网页源码提取相关ID
 
 1. 查看课程号和教学班：想选的课“教学班”第二行点击复制ID即可复制课号+教学班号
 2. 查看课程类型：标签页第二行的字符串即为课程类型
-3. 使用命令选课，格式为`autoelect [课程类型ID] [课程号ID] [256位教学班ID]`：
+3. 终端进入源码目录后，使用命令选课，格式为 `python3 autoelect.py [选项] [课程类型ID] [课程号ID] [256位教学班ID]`：
 
-        autoelect 01 AAAA... aaaa... 10 BBBB bbbb...
+        python3 autoelect.py 01 AAAA... aaaa... 10 BBBB bbbb...
 
     上述命令将会选`01`课程类型下的`AAAA`课的`aaaa`（省略256位）教学班和`10`课程类型下的`BBBB`课的`bbbb`（省略256位）课，如果需要更多可以在后面继续添加。
 
-    注：程序运行过程中输入`s`可以查看选课状态
+    注：程序运行过程中输入`s`可以查看选课状态。如需全自动识别验证码，请在命令中加上 `-o` 参数。
+
+输入密码后卡死/出现 NotOpenSSLWarning：Mac 系统 SSL 冲突，终端运行 `pip3 install "urllib3<2"` 即可解决。
 
 ## 抢课说明
 - **本程序所有操作均保证当前课程不会减少，即无论你是否已经选上课、无论是否人满等各种情况都不会影响已选课程。换言之，无论何时均保证课程只多不少，重复提交不会影响当前课表。**

--- a/README.md
+++ b/README.md
@@ -25,12 +25,14 @@ V2协议分析：<https://github.com/MXWXZ/sjtu-automata/blob/master/Protocol%20
 Linux > macOS > Windows
 
 ## 安装
-    
-    pip3 install sjtu-automata
-
-## 升级
-
-    pip3 install sjtu-automata --upgrade
+1. 请先手动安装必备的网络请求库：
+```Bash
+pip3 install requests
+```
+2. 从 GitHub 拉取最新修复版:
+'''Bash
+pip3 install git+[https://github.com/MXWXZ/sjtu-automata.git](https://github.com/MXWXZ/sjtu-automata.git) --upgrade --no-build-isolation
+```
 
 ### [可选]验证码自动识别
 Windows可以不装，Linux如无图形界面且无法通过其他方式打开`captcha.jpeg`文件需要安装。

--- a/sjtu_automata/credential.py
+++ b/sjtu_automata/credential.py
@@ -1,6 +1,7 @@
 from time import sleep
 from time import time
 from getpass import getpass
+import re
 
 import requests
 from PIL import Image
@@ -57,7 +58,7 @@ def _bypass_captcha(session, url, useocr):
 def _login(session, sid, returl, se, client, username, password, code, uuid):
     # return 0 suc, 1 wrong credential, 2 code error, 3 30s ban
     data = {'sid': sid, 'returl': returl, 'se': se, 'client': client, 'user': username,
-            'pass': password, 'captcha': code, 'v': '', 'uuid': uuid}
+            'pass': password, 'captcha': code, 'v': '', 'uuid': uuid, 'lt': 'p'}
     req = session.post(
         'https://jaccount.sjtu.edu.cn/jaccount/ulogin', data=data)
 
@@ -69,6 +70,16 @@ def _login(session, sid, returl, se, client, username, password, code, uuid):
         error_msg = result.get('error', '')
 
         if errno == 0:
+            # Follow redirect URL to complete auth cookie setup
+            redirect_url = result.get('url', '')
+            if redirect_url:
+                # JAccount may return relative URL, make it absolute
+                if not redirect_url.startswith('http'):
+                    redirect_url = 'https://jaccount.sjtu.edu.cn' + redirect_url
+                try:
+                    session.get(redirect_url)
+                except RequestException:
+                    pass  # redirect failed but login POST succeeded, cookies are already set
             return 0  # login success
         if error_code == 'WRONG_CAPTCHA' or '验证码' in error_msg:
             return 2  # wrong captcha
@@ -90,8 +101,23 @@ def _login(session, sid, returl, se, client, username, password, code, uuid):
         return 3
     elif '<i class="fa fa-gear" aria-hidden="true" id="wdyy_szbtn">' in req.text:
         return 0
-    else:
-        raise AutomataError(f'Unexpected response, first 500 chars: {req.text[:500]}')
+
+    # Dump full response for debugging new JAccount page structure
+    with open('jaccount_response.html', 'w', encoding='utf-8') as f:
+        f.write(req.text)
+    print('[Debug] Full response written to jaccount_response.html')
+
+    # Check for common error indicators in newer JAccount pages
+    if 'errno' in req.text or 'error' in req.text:
+        err_match = re.search(r'"error"\s*:\s*"([^"]+)"', req.text)
+        if err_match:
+            raise AutomataError(f'JAccount error: {err_match.group(1)}')
+    if 'login-form' in req.text or 'login-card' in req.text or 'SJTU Single Sign On' in req.text:
+        # Returned to login page — likely captcha error, but could be wrong password.
+        # Return 2 to retry captcha; if it loops forever, the password is probably wrong.
+        print('[Debug] Returned to login page, retrying with new captcha...')
+        return 2
+    raise AutomataError(f'Unexpected response. Full HTML saved to jaccount_response.html. First 500 chars: {req.text[:500]}')
 
 
 def login(url, useocr=False):
@@ -134,8 +160,7 @@ def login(url, useocr=False):
                          username, password, code, uuid)
 
             if res == 2:
-                if not useocr:
-                    print('Wrong captcha! Try again!')
+                print('Wrong captcha! Retrying...')
                 continue
             elif res == 1:
                 print('Wrong username or password! Try again!')

--- a/sjtu_automata/credential.py
+++ b/sjtu_automata/credential.py
@@ -42,8 +42,9 @@ def _bypass_captcha(session, url, useocr):
 
     if useocr:
         code = autocaptcha('captcha.jpeg').strip()
-        if not code.isalpha():
-            code = '1234'   # cant recongnize, go for next round
+        # SJTU captcha is 4 alphanumeric chars (letters + digits)
+        if not code or len(code) < 4:
+            code = '1234'   # cant recognize, go for next round
     else:
         img = Image.open('captcha.jpeg')
         img.show()
@@ -60,18 +61,37 @@ def _login(session, sid, returl, se, client, username, password, code, uuid):
     req = session.post(
         'https://jaccount.sjtu.edu.cn/jaccount/ulogin', data=data)
 
-    # result
-    # be careful return english version website in english OS
+    # Try JSON response first (new JAccount API format)
+    try:
+        result = req.json()
+        errno = result.get('errno', -1)
+        error_code = result.get('code', '')
+        error_msg = result.get('error', '')
+
+        if errno == 0:
+            return 0  # login success
+        if error_code == 'WRONG_CAPTCHA' or '验证码' in error_msg:
+            return 2  # wrong captcha
+        if error_code == 'WRONG_CREDENTIAL' or '用户名' in error_msg or '密码' in error_msg:
+            return 1  # wrong credential
+        # fallback: check errno for other known errors
+        if errno == 1:
+            return 1
+        raise AutomataError(f'Unexpected JSON response: {result}')
+    except ValueError:
+        pass  # not JSON, fallback to legacy HTML parsing
+
+    # Legacy HTML-based detection (fallback)
     if '请正确填写验证码' in req.text or 'wrong captcha' in req.text:
         return 2
     elif '请正确填写你的用户名和密码' in req.text or 'wrong username or password' in req.text:
         return 1
     elif '30秒后' in req.text:  # 30s ban
         return 3
-    elif '<i class="fa fa-gear" aria-hidden="true" id="wdyy_szbtn">':
+    elif '<i class="fa fa-gear" aria-hidden="true" id="wdyy_szbtn">' in req.text:
         return 0
     else:
-        raise AutomataError
+        raise AutomataError(f'Unexpected response, first 500 chars: {req.text[:500]}')
 
 
 def login(url, useocr=False):
@@ -94,15 +114,8 @@ def login(url, useocr=False):
         while True:
             session = _create_session()
             req = _get_login_page(session, url)
-            captcha_id = re_search(r'img.src = \'captcha\?(.*)\'', req)
-            if not captcha_id:
-                print('Captcha not found! Retrying...')
-                sleep(3)
-                continue
-            captcha_id += get_timestamp()
-            captcha_url = 'https://jaccount.sjtu.edu.cn/jaccount/captcha?' + captcha_id
-            code = _bypass_captcha(session, captcha_url, useocr)
 
+            # Extract all params first, before constructing captcha URL
             sid = re_search(r'sid: "(.*?)"', req)
             returl = re_search(r'returl:"(.*?)"', req)
             se = re_search(r'se: "(.*?)"', req)
@@ -112,6 +125,10 @@ def login(url, useocr=False):
                 print('Params not found! Retrying...')
                 sleep(3)
                 continue
+
+            # Construct captcha URL with fresh timestamp (replace, not append)
+            captcha_url = 'https://jaccount.sjtu.edu.cn/jaccount/captcha?uuid=' + uuid + '&t=' + get_timestamp()
+            code = _bypass_captcha(session, captcha_url, useocr)
 
             res = _login(session, sid, returl, se, client,
                          username, password, code, uuid)


### PR DESCRIPTION
感谢开发！
近期发现，默认参数可以正常运行，但如果带了`-o`会抛出`Can't find student id!`，故做了一些小修复：

+ **适配最新 JAccount JSON 接口**：目前的 `ulogin` 接口在报错时不再返回完整的 HTML，而是返回轻量级的 JSON（如 `{"code": "WRONG_CAPTCHA"}`）。在 `_login` 函数中加入了优先解析 JSON 的逻辑，捕获 `WRONG_CAPTCHA` 和 `errno`。
+ **修复 OCR 验证码重试死锁**：修复了原代码中基于旧版 HTML 提示语失效导致的验证码错误误判。现在当 OCR 识别错误时，程序能正确返回 `2` 并触发下一轮获取验证码的循环溃。
+ **修复验证码数字被过滤的 Bug**：在 `_bypass_captcha` 函数中，将 `if not code.isalpha():` 更改为长度校验 `if not code or len(code) < 4:`。
+ **修复验证码 URL 构造问题**：调整了 `login` 函数中的提取顺序，先抓取 `uuid`，再利用 timestamp 拼接合法的 `captcha_url`。
+ **调整Readme**：强调`pip3`安装已失效，需要拉取新代码。